### PR TITLE
Improve profile page spacing and fix CSS reset

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -21,8 +21,6 @@
 
 * {
   box-sizing: border-box;
-  padding: 0;
-  margin: 0;
 }
 
 html,

--- a/app/u/[username]/content.tsx
+++ b/app/u/[username]/content.tsx
@@ -78,9 +78,9 @@ export function PublicProfileContent({ username }: { username: string }) {
             </p>
           </section>
         ) : (
-          <>
+          <div className="flex flex-col gap-4">
             {/* Character card */}
-            <section className="pixel-border bg-black p-4 mb-6" aria-labelledby="character-heading">
+            <section className="pixel-border bg-black p-4" aria-labelledby="character-heading">
               <div className="flex justify-between items-start mb-4">
                 <div>
                   <div className="flex items-center gap-2">
@@ -122,7 +122,7 @@ export function PublicProfileContent({ username }: { username: string }) {
             </section>
 
             {/* Active commitments */}
-            <section className="mb-6" aria-labelledby="commitments-heading">
+            <section aria-labelledby="commitments-heading">
               <h3 id="commitments-heading" className="text-sm text-gray-400 mb-3">
                 ACTIVE COMMITMENTS ({commitments.length})
               </h3>
@@ -161,12 +161,12 @@ export function PublicProfileContent({ username }: { username: string }) {
                 </ul>
               )}
             </section>
-          </>
+          </div>
         )}
 
         {/* Graveyard */}
         {graveyard.length > 0 && (
-          <section aria-labelledby="graveyard-heading">
+          <section className="mt-4" aria-labelledby="graveyard-heading">
             <h3 id="graveyard-heading" className="text-sm text-gray-400 mb-3">
               GRAVEYARD ({graveyard.length})
             </h3>

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -34,7 +34,7 @@ export function AppShell({ children, rightNav, centered = true }: AppShellProps)
       <main
         id="main"
         className={`flex-1 flex flex-col px-6 ${
-          centered ? "items-center justify-center py-10" : "items-center pt-10 pb-10"
+          centered ? "items-center justify-center py-10" : "items-center pt-4 pb-10"
         }`}
       >
         {children}


### PR DESCRIPTION
## Summary
- Use flexbox gap for consistent section spacing on profile page
- Remove redundant padding/margin reset from globals.css (conflicted with Tailwind utilities)
- Reduce navbar-to-content padding for tighter layout

## Test plan
- [ ] Visit `/u/bustakar` and verify spacing between character card, active commitments, graveyard, and footer
- [ ] Check that spacing looks balanced on mobile and desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)