### PR TITLE
Add one-way difficulty upgrade feature

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -31,6 +31,10 @@ export default function Dashboard() {
     commitmentId: string | null;
   }>({ isOpen: false, commitmentId: null });
   const [killCharacterDialog, setKillCharacterDialog] = useState(false);
+  const [upgradeDialog, setUpgradeDialog] = useState<{
+    isOpen: boolean;
+    newDifficulty: "medium" | "hard" | null;
+  }>({ isOpen: false, newDifficulty: null });
 
   // Convex queries
   const user = useQuery(api.users.get);
@@ -45,6 +49,7 @@ export default function Dashboard() {
   const deactivateCommitment = useMutation(api.commitments.deactivate);
   const renewCommitment = useMutation(api.commitments.renew);
   const voluntaryDeath = useMutation(api.scannerMutations.voluntaryDeath);
+  const upgradeDifficulty = useMutation(api.characters.upgradeDifficulty);
 
   // Convex actions (server-side GitHub operations)
   const getUserRepos = useAction(api.githubActions.getUserRepos);
@@ -220,6 +225,28 @@ export default function Dashboard() {
     setKillCharacterDialog(false);
   };
 
+  const handleUpgradeDifficulty = (newDifficulty: "medium" | "hard") => {
+    setUpgradeDialog({ isOpen: true, newDifficulty });
+  };
+
+  const handleConfirmUpgrade = async () => {
+    if (upgradeDialog.newDifficulty) {
+      try {
+        await upgradeDifficulty({ newDifficulty: upgradeDialog.newDifficulty });
+        showSuccess(`Difficulty upgraded to ${upgradeDialog.newDifficulty}!`);
+      } catch (error) {
+        console.error("Failed to upgrade difficulty:", error);
+        const message = error instanceof Error ? error.message : "Failed to upgrade difficulty";
+        showError(message);
+      }
+    }
+    setUpgradeDialog({ isOpen: false, newDifficulty: null });
+  };
+
+  const handleCancelUpgrade = () => {
+    setUpgradeDialog({ isOpen: false, newDifficulty: null });
+  };
+
   const handleRenew = async (id: string) => {
     try {
       await renewCommitment({ commitmentId: id as Id<"commitments"> });
@@ -281,6 +308,7 @@ export default function Dashboard() {
                   activeRepoCount={commitments?.length || 0}
                   avatarUrl={avatarUrl}
                   onKillCharacter={handleKillCharacter}
+                  onUpgradeDifficulty={handleUpgradeDifficulty}
                 />
               </section>
 
@@ -348,6 +376,22 @@ export default function Dashboard() {
         variant="danger"
         onConfirm={handleConfirmKillCharacter}
         onCancel={handleCancelKillCharacter}
+      />
+
+      {/* Confirmation Dialog for upgrading difficulty */}
+      <ConfirmDialog
+        isOpen={upgradeDialog.isOpen}
+        title="Upgrade Difficulty"
+        message={`This change is permanent and cannot be undone.\n\n${
+          upgradeDialog.newDifficulty === "medium"
+            ? "Medium difficulty:\n• HP drain: 0.5 per repo/hour (was 0.2)\n• XP multiplier: 2x (was 1x)"
+            : "Hard difficulty:\n• HP drain: 1.0 per repo/hour (was 0.2-0.5)\n• XP multiplier: 3x (was 1-2x)"
+        }`}
+        confirmText={`Upgrade to ${upgradeDialog.newDifficulty?.toUpperCase()}`}
+        cancelText="Cancel"
+        variant="warning"
+        onConfirm={handleConfirmUpgrade}
+        onCancel={handleCancelUpgrade}
       />
     </AppShell>
   );

--- a/components/character-card.tsx
+++ b/components/character-card.tsx
@@ -22,6 +22,7 @@ interface CharacterCardProps {
   activeRepoCount: number;
   avatarUrl?: string;
   onKillCharacter?: () => void;
+  onUpgradeDifficulty?: (newDifficulty: "medium" | "hard") => void;
 }
 
 const HP_DRAIN_RATES: Record<Difficulty, number> = {
@@ -42,7 +43,7 @@ const DIFFICULTY_COLORS: Record<Difficulty, string> = {
   hard: "text-red-400 border-red-700 bg-red-900/30",
 };
 
-export function CharacterCard({ character, activeRepoCount, avatarUrl, onKillCharacter }: CharacterCardProps) {
+export function CharacterCard({ character, activeRepoCount, avatarUrl, onKillCharacter, onUpgradeDifficulty }: CharacterCardProps) {
   const difficulty = character.difficulty || "easy";
   const hourlyDrain = HP_DRAIN_RATES[difficulty] * activeRepoCount;
   const xpMultiplier = XP_MULTIPLIERS[difficulty];
@@ -109,15 +110,30 @@ export function CharacterCard({ character, activeRepoCount, avatarUrl, onKillCha
         </div>
       )}
 
-      {/* Kill character button */}
-      {onKillCharacter && (
-        <div className="mt-4 pt-4 border-t border-gray-700">
-          <button
-            onClick={onKillCharacter}
-            className="w-full text-xs text-gray-500 hover:text-red-400 transition-colors py-2"
-          >
-            End character...
-          </button>
+      {/* Footer actions */}
+      {(onUpgradeDifficulty || onKillCharacter) && (
+        <div className="mt-4 pt-4 border-t border-gray-700 space-y-2">
+          {/* Upgrade difficulty link - only show if not on hard */}
+          {onUpgradeDifficulty && difficulty !== "hard" && (
+            <button
+              onClick={() => {
+                const nextDifficulty = difficulty === "easy" ? "medium" : "hard";
+                onUpgradeDifficulty(nextDifficulty);
+              }}
+              className="w-full text-xs text-gray-500 hover:text-yellow-400 transition-colors py-2"
+            >
+              Upgrade difficulty...
+            </button>
+          )}
+          {/* Kill character button */}
+          {onKillCharacter && (
+            <button
+              onClick={onKillCharacter}
+              className="w-full text-xs text-gray-500 hover:text-red-400 transition-colors py-2"
+            >
+              End character...
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/components/confirm-dialog.tsx
+++ b/components/confirm-dialog.tsx
@@ -8,7 +8,7 @@ interface ConfirmDialogProps {
   message: string;
   confirmText?: string;
   cancelText?: string;
-  variant?: "danger" | "default";
+  variant?: "danger" | "warning" | "default";
   onConfirm: () => void;
   onCancel: () => void;
 }
@@ -89,7 +89,7 @@ export function ConfirmDialog({
         >
           {title}
         </h2>
-        <p className="text-xs text-gray-400 mb-6">{message}</p>
+        <p className="text-xs text-gray-400 mb-6 whitespace-pre-line">{message}</p>
 
         <div className="flex gap-3 justify-end">
           <button
@@ -104,7 +104,9 @@ export function ConfirmDialog({
             className={`text-xs px-4 py-2 ${
               variant === "danger"
                 ? "bg-red-700 text-white hover:bg-red-600"
-                : "bg-[var(--pixel-green)] text-black hover:bg-[var(--pixel-dark-green)]"
+                : variant === "warning"
+                  ? "bg-yellow-600 text-black hover:bg-yellow-500"
+                  : "bg-[var(--pixel-green)] text-black hover:bg-[var(--pixel-dark-green)]"
             }`}
           >
             {confirmText}

--- a/convex/characters.ts
+++ b/convex/characters.ts
@@ -184,3 +184,53 @@ export const getGraveyard = query({
       .collect();
   },
 });
+
+// Difficulty order for validation (can only increase)
+const DIFFICULTY_ORDER: Record<string, number> = {
+  easy: 0,
+  medium: 1,
+  hard: 2,
+};
+
+// Upgrade difficulty (one-way - can only increase)
+export const upgradeDifficulty = mutation({
+  args: {
+    newDifficulty: v.union(v.literal("medium"), v.literal("hard")),
+  },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Not authenticated");
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_clerk_id", (q) => q.eq("clerkId", identity.subject))
+      .first();
+
+    if (!user) throw new Error("User not found");
+
+    // Get user's living character
+    const character = await ctx.db
+      .query("characters")
+      .withIndex("by_user", (q) => q.eq("userId", user._id))
+      .filter((q) => q.eq(q.field("isAlive"), true))
+      .first();
+
+    if (!character) throw new Error("No living character found");
+
+    const currentDifficulty = character.difficulty || "easy";
+    const currentOrder = DIFFICULTY_ORDER[currentDifficulty];
+    const newOrder = DIFFICULTY_ORDER[args.newDifficulty];
+
+    // Validate upgrade direction (can only increase)
+    if (newOrder <= currentOrder) {
+      throw new Error("Can only upgrade to a higher difficulty");
+    }
+
+    // Update character difficulty
+    await ctx.db.patch(character._id, {
+      difficulty: args.newDifficulty,
+    });
+
+    return { success: true };
+  },
+});


### PR DESCRIPTION
## Summary

- Allow players to upgrade difficulty (easy→medium→hard) but not decrease
- Show permanent warning dialog with new HP drain rate and XP multiplier
- Add "warning" variant to ConfirmDialog component

Closes #27

## Test plan

- [ ] Create character on "easy" difficulty
- [ ] Click "Upgrade difficulty..." link
- [ ] Verify warning dialog shows correct stats
- [ ] Confirm upgrade, verify badge updates to "MEDIUM"
- [ ] Verify upgrade link now offers "hard" only
- [ ] Upgrade to "hard", verify no upgrade option shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)