### PR TITLE
Rebalance HP drain rates and PR rewards

### DIFF
--- a/components/character-card.tsx
+++ b/components/character-card.tsx
@@ -25,9 +25,9 @@ interface CharacterCardProps {
 }
 
 const HP_DRAIN_RATES: Record<Difficulty, number> = {
-  easy: 0.2,
-  medium: 0.5,
-  hard: 1.0,
+  easy: 0.5,
+  medium: 1.5,
+  hard: 4.0,
 };
 
 const XP_MULTIPLIERS: Record<Difficulty, number> = {

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -9,9 +9,9 @@ export type Difficulty = "easy" | "medium" | "hard";
 
 // HP drain rates per repo per hour by difficulty
 export const HP_DRAIN_RATES: Record<Difficulty, number> = {
-  easy: 0.2,
-  medium: 0.5,
-  hard: 1.0,
+  easy: 0.5,   // 12 HP/day → ~8 days survival without PRs
+  medium: 1.5, // 36 HP/day → ~2.8 days survival without PRs
+  hard: 4.0,   // 96 HP/day → ~1 day survival without PRs
 };
 
 // XP multipliers by difficulty
@@ -29,8 +29,8 @@ export const HP_DRAIN_PER_REPO_PER_HOUR = HP_DRAIN_RATES.easy;
 // PRs: Only source of HP, higher reward if PR closes issues
 export const REWARDS = {
   commit: { hp: 0, xp: 10, dailyCap: 5 },
-  prMergedWithIssue: { hp: 12, xp: 50, dailyCap: null },
-  prMergedNoIssue: { hp: 6, xp: 25, dailyCap: null },
+  prMergedWithIssue: { hp: 24, xp: 50, dailyCap: null },
+  prMergedNoIssue: { hp: 12, xp: 25, dailyCap: null },
   // Streaks
   streak7: { hp: 5, xp: 15 },
   streak30: { hp: 15, xp: 50 },


### PR DESCRIPTION
## Summary

- Increase HP drain rates to make difficulty matter
- Double PR HP rewards to compensate

| Difficulty | Drain/hour | Survival | PRs to break even |
|------------|------------|----------|-------------------|
| Easy | 0.5 | ~8 days | ~1/day |
| Medium | 1.5 | ~2.8 days | ~2-3/day |
| Hard | 4.0 | ~1 day | ~5-6/day |

Closes #29

## Test plan

- [ ] Verify HP drain displays correctly in character card
- [ ] Verify new drain rates in game.ts
- [ ] Verify PR rewards doubled in game.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)