### PR TITLE
Update domain references to armory.rip

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Your character's HP constantly drains from active repo commitments. Stay alive by shipping code — merge PRs to heal, make commits to earn XP. Neglect your repos and your character dies.
 
-[Live Demo](https://armory-brown.vercel.app)
+[Live Demo](https://armory.rip)
 
 ## How It Works
 
@@ -19,20 +19,20 @@ Your character's HP constantly drains from active repo commitments. Stay alive b
 
 | Action | HP | XP | Notes |
 |--------|----|----|-------|
-| Merged PR (closes issue) | +12 | +50 | Best way to heal |
-| Merged PR (no issue) | +6 | +25 | |
+| Merged PR (closes issue) | +24 | +50 | Best way to heal |
+| Merged PR (no issue) | +12 | +25 | |
 | Commit | - | +10 | Max 5/day per repo |
-| Active repo | -0.2 to -1.0/hr | - | Based on difficulty |
+| Active repo | -0.5 to -4.0/hr | - | Based on difficulty |
 | Early exit penalty | -50 | - | Leave commitment early |
 | Complete 30-day commitment | +10 | +25 | |
 
 ### Difficulty Modes
 
-| Mode | HP Drain/hr | XP Multiplier |
-|------|-------------|---------------|
-| Easy | 0.2 | 1x |
-| Medium | 0.5 | 2x |
-| Hard | 1.0 | 3x |
+| Mode | HP Drain/hr | XP Multiplier | Survival (no PRs) |
+|------|-------------|---------------|-------------------|
+| Easy | 0.5 | 1x | ~8 days |
+| Medium | 1.5 | 2x | ~2.8 days |
+| Hard | 4.0 | 3x | ~1 day |
 
 ## Tech Stack
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import { ClerkProvider } from "@clerk/nextjs";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { ToastProvider } from "@/components/toast";
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://armory.dev";
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://armory.rip";
 
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
@@ -70,7 +70,7 @@ export const metadata: Metadata = {
     description:
       "Stake your HP on GitHub activity. Survive or perish. Turn your commits into XP.",
     images: ["/og-image.png"],
-    creator: "@armorydev",
+    creator: "@armoryrip",
   },
   alternates: {
     canonical: siteUrl,

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://armory.dev";
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://armory.rip";
 
   return {
     rules: [

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from "next";
 import { ConvexHttpClient } from "convex/browser";
 import { api } from "../convex/_generated/api";
 
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://armory.dev";
+const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://armory.rip";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Static pages

--- a/app/u/[username]/page.tsx
+++ b/app/u/[username]/page.tsx
@@ -3,7 +3,7 @@ import { ConvexHttpClient } from "convex/browser";
 import { api } from "../../../convex/_generated/api";
 import { PublicProfileContent } from "./content";
 
-const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://armory.dev";
+const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://armory.rip";
 
 // Generate dynamic metadata for profile pages
 export async function generateMetadata({


### PR DESCRIPTION
## Summary

- Update all domain references from placeholder URLs to `armory.rip`
- Update Twitter handle to `@armoryrip`
- Update README with current HP drain rates and rewards

Closes #33

## Files Changed

- `README.md` - Live demo URL + HP mechanics table
- `app/layout.tsx` - Site URL fallback + Twitter creator
- `app/robots.ts` - Base URL fallback
- `app/sitemap.ts` - Base URL fallback
- `app/u/[username]/page.tsx` - Site URL fallback

## Test plan

- [ ] Verify README links point to armory.rip
- [ ] Verify SEO meta tags use armory.rip
- [ ] Verify sitemap uses armory.rip

🤖 Generated with [Claude Code](https://claude.com/claude-code)