### PR TITLE
Add game rules page and fix outdated values

### DIFF
--- a/app/rules/content.tsx
+++ b/app/rules/content.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import Link from "next/link";
+import { AppShell } from "@/components/app-shell";
+
+export function RulesContent() {
+  return (
+    <AppShell centered={false}>
+      <div className="w-full max-w-2xl space-y-8 pb-8">
+        <div className="flex items-center justify-between">
+          <h1 className="text-2xl text-[var(--pixel-gold)]">GAME RULES</h1>
+          <Link
+            href="/"
+            className="text-xs text-gray-500 hover:text-gray-400"
+          >
+            ← Back to game
+          </Link>
+        </div>
+
+        {/* HP System */}
+        <section className="pixel-border bg-black p-6">
+          <h2 className="text-lg text-red-400 mb-4">HP SYSTEM</h2>
+          <p className="text-sm text-gray-400 mb-4">
+            Your HP drains continuously based on your active repositories and difficulty level.
+            When HP reaches 0, your character dies.
+          </p>
+          <div className="space-y-2 text-sm">
+            <p className="text-gray-500 mb-2">HP Drain Rates (per active repo):</p>
+            <div className="grid grid-cols-3 gap-4">
+              <div className="p-3 border border-green-700 bg-green-900/20">
+                <p className="text-green-400 font-bold">Easy</p>
+                <p className="text-gray-400">0.5 HP/hour</p>
+                <p className="text-gray-500 text-xs">12 HP/day</p>
+                <p className="text-gray-500 text-xs">~8 days survival</p>
+              </div>
+              <div className="p-3 border border-yellow-700 bg-yellow-900/20">
+                <p className="text-yellow-400 font-bold">Medium</p>
+                <p className="text-gray-400">1.5 HP/hour</p>
+                <p className="text-gray-500 text-xs">36 HP/day</p>
+                <p className="text-gray-500 text-xs">~2.8 days survival</p>
+              </div>
+              <div className="p-3 border border-red-700 bg-red-900/20">
+                <p className="text-red-400 font-bold">Hard</p>
+                <p className="text-gray-400">4.0 HP/hour</p>
+                <p className="text-gray-500 text-xs">96 HP/day</p>
+                <p className="text-gray-500 text-xs">~1 day survival</p>
+              </div>
+            </div>
+            <p className="text-xs text-gray-500 mt-3">
+              * Survival time assumes 100 HP, 1 active repo, no PRs merged
+            </p>
+          </div>
+        </section>
+
+        {/* Earning HP */}
+        <section className="pixel-border bg-black p-6">
+          <h2 className="text-lg text-red-400 mb-4">EARNING HP</h2>
+          <p className="text-sm text-gray-400 mb-4">
+            <strong className="text-white">Pull Requests are the only way to earn HP.</strong>{" "}
+            Commits give XP but no HP.
+          </p>
+          <div className="space-y-3 text-sm">
+            <div className="flex justify-between items-center p-3 border border-gray-700">
+              <div>
+                <p className="text-white">PR merged (closes issue)</p>
+                <p className="text-xs text-gray-500">PR description references and closes an issue</p>
+              </div>
+              <div className="text-right">
+                <p className="text-red-400">+24 HP</p>
+                <p className="text-purple-400">+50 XP</p>
+              </div>
+            </div>
+            <div className="flex justify-between items-center p-3 border border-gray-700">
+              <div>
+                <p className="text-white">PR merged (no issue)</p>
+                <p className="text-xs text-gray-500">PR merged without closing an issue</p>
+              </div>
+              <div className="text-right">
+                <p className="text-red-400">+12 HP</p>
+                <p className="text-purple-400">+25 XP</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Earning XP */}
+        <section className="pixel-border bg-black p-6">
+          <h2 className="text-lg text-purple-400 mb-4">EARNING XP</h2>
+          <p className="text-sm text-gray-400 mb-4">
+            XP determines your level. Every 100 XP = 1 level.
+          </p>
+          <div className="space-y-3 text-sm">
+            <div className="flex justify-between items-center p-3 border border-gray-700">
+              <div>
+                <p className="text-white">Commit pushed</p>
+                <p className="text-xs text-gray-500">Max 5 commits per day count</p>
+              </div>
+              <p className="text-purple-400">+10 XP</p>
+            </div>
+            <div className="flex justify-between items-center p-3 border border-gray-700">
+              <div>
+                <p className="text-white">7-day streak</p>
+              </div>
+              <div className="text-right">
+                <p className="text-red-400">+5 HP</p>
+                <p className="text-purple-400">+15 XP</p>
+              </div>
+            </div>
+            <div className="flex justify-between items-center p-3 border border-gray-700">
+              <div>
+                <p className="text-white">30-day streak</p>
+              </div>
+              <div className="text-right">
+                <p className="text-red-400">+15 HP</p>
+                <p className="text-purple-400">+50 XP</p>
+              </div>
+            </div>
+            <div className="flex justify-between items-center p-3 border border-gray-700">
+              <div>
+                <p className="text-white">100-day streak</p>
+              </div>
+              <div className="text-right">
+                <p className="text-red-400">+30 HP</p>
+                <p className="text-purple-400">+200 XP</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* XP Multipliers */}
+        <section className="pixel-border bg-black p-6">
+          <h2 className="text-lg text-purple-400 mb-4">XP MULTIPLIERS</h2>
+          <p className="text-sm text-gray-400 mb-4">
+            Higher difficulty = higher XP multiplier on all rewards.
+          </p>
+          <div className="grid grid-cols-3 gap-4 text-sm">
+            <div className="p-3 border border-green-700 bg-green-900/20 text-center">
+              <p className="text-green-400 font-bold">Easy</p>
+              <p className="text-2xl text-white">1x</p>
+            </div>
+            <div className="p-3 border border-yellow-700 bg-yellow-900/20 text-center">
+              <p className="text-yellow-400 font-bold">Medium</p>
+              <p className="text-2xl text-white">2x</p>
+            </div>
+            <div className="p-3 border border-red-700 bg-red-900/20 text-center">
+              <p className="text-red-400 font-bold">Hard</p>
+              <p className="text-2xl text-white">3x</p>
+            </div>
+          </div>
+        </section>
+
+        {/* Diversity Bonus */}
+        <section className="pixel-border bg-black p-6">
+          <h2 className="text-lg text-blue-400 mb-4">DIVERSITY BONUS</h2>
+          <p className="text-sm text-gray-400 mb-4">
+            Contributing to multiple repos in a 6-hour window gives an XP multiplier.
+          </p>
+          <div className="space-y-2 text-sm">
+            <p className="text-gray-500">Formula: 1 + (repos - 1) × 0.2</p>
+            <div className="grid grid-cols-4 gap-2 mt-3">
+              <div className="p-2 border border-gray-700 text-center">
+                <p className="text-xs text-gray-500">1 repo</p>
+                <p className="text-white">1.0x</p>
+              </div>
+              <div className="p-2 border border-gray-700 text-center">
+                <p className="text-xs text-gray-500">2 repos</p>
+                <p className="text-blue-400">1.2x</p>
+              </div>
+              <div className="p-2 border border-gray-700 text-center">
+                <p className="text-xs text-gray-500">3 repos</p>
+                <p className="text-blue-400">1.4x</p>
+              </div>
+              <div className="p-2 border border-gray-700 text-center">
+                <p className="text-xs text-gray-500">4 repos</p>
+                <p className="text-blue-400">1.6x</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Commitments */}
+        <section className="pixel-border bg-black p-6">
+          <h2 className="text-lg text-[var(--pixel-gold)] mb-4">COMMITMENTS</h2>
+          <p className="text-sm text-gray-400 mb-4">
+            Add repos to your roster to commit to them. Each repo you add starts draining HP.
+          </p>
+          <div className="space-y-3 text-sm">
+            <div className="p-3 border border-gray-700">
+              <p className="text-white">Commitment Period</p>
+              <p className="text-xs text-gray-500">30 days minimum per repo</p>
+            </div>
+            <div className="flex justify-between items-center p-3 border border-[var(--pixel-gold)] bg-yellow-900/20">
+              <div>
+                <p className="text-white">Complete commitment</p>
+                <p className="text-xs text-gray-500">Stay alive for 30 days with repo active</p>
+              </div>
+              <div className="text-right">
+                <p className="text-red-400">+100 HP (full heal!)</p>
+                <p className="text-purple-400">+1000 XP</p>
+              </div>
+            </div>
+            <div className="flex justify-between items-center p-3 border border-gray-700">
+              <div>
+                <p className="text-white">Renew commitment</p>
+                <p className="text-xs text-gray-500">Keep repo active after 30 days</p>
+              </div>
+              <p className="text-purple-400">+250 XP</p>
+            </div>
+            <div className="flex justify-between items-center p-3 border border-red-700 bg-red-900/20">
+              <div>
+                <p className="text-white">Early exit penalty</p>
+                <p className="text-xs text-gray-500">Remove repo before 30 days</p>
+              </div>
+              <p className="text-red-400">-50 HP</p>
+            </div>
+          </div>
+        </section>
+
+        {/* Death & Rebirth */}
+        <section className="pixel-border bg-black p-6">
+          <h2 className="text-lg text-gray-400 mb-4">DEATH & REBIRTH</h2>
+          <p className="text-sm text-gray-400 mb-4">
+            When your HP reaches 0, your character dies. You can create a new character to start fresh.
+          </p>
+          <div className="space-y-2 text-sm text-gray-500">
+            <p>• All progress is lost (HP, XP, level, streak)</p>
+            <p>• Your graveyard records fallen characters</p>
+            <p>• Create a new character anytime after death</p>
+            <p>• Choose a new difficulty for each life</p>
+          </div>
+        </section>
+
+        {/* Difficulty Upgrade */}
+        <section className="pixel-border bg-black p-6">
+          <h2 className="text-lg text-yellow-400 mb-4">DIFFICULTY UPGRADE</h2>
+          <p className="text-sm text-gray-400 mb-4">
+            You can upgrade difficulty at any time, but you cannot downgrade.
+          </p>
+          <div className="space-y-2 text-sm text-gray-500">
+            <p>• Easy → Medium → Hard (one-way only)</p>
+            <p>• Higher difficulty = faster HP drain</p>
+            <p>• Higher difficulty = more XP per action</p>
+            <p>• Choose wisely - no going back!</p>
+          </div>
+        </section>
+      </div>
+    </AppShell>
+  );
+}

--- a/app/rules/page.tsx
+++ b/app/rules/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import { RulesContent } from "./content";
+
+export const metadata: Metadata = {
+  title: "Game Rules | Armory",
+  description: "Complete rules for the Armory GitHub RPG - HP drain, XP rewards, difficulty levels, and more.",
+};
+
+export default function RulesPage() {
+  return <RulesContent />;
+}

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -14,9 +14,14 @@ export function AppShell({ children, rightNav, centered = true }: AppShellProps)
     <div className="min-h-screen flex flex-col">
       {/* Navbar - full width */}
       <header className="w-full px-4 py-3 border-b border-gray-700 flex justify-between items-center">
-        <Link href="/" className="text-xl text-[var(--pixel-gold)] hover:opacity-80">
-          ARMORY
-        </Link>
+        <div className="flex items-center gap-4">
+          <Link href="/" className="text-xl text-[var(--pixel-gold)] hover:opacity-80">
+            ARMORY
+          </Link>
+          <Link href="/rules" className="text-gray-500 hover:text-gray-400 text-xs">
+            Rules
+          </Link>
+        </div>
         <div className="flex items-center gap-4">
           {rightNav}
           <a

--- a/components/character-card.tsx
+++ b/components/character-card.tsx
@@ -2,8 +2,7 @@
 
 import { HpBar } from "./hp-bar";
 import { XpBar } from "./xp-bar";
-
-type Difficulty = "easy" | "medium" | "hard";
+import { HP_DRAIN_RATES, XP_MULTIPLIERS, type Difficulty } from "@/convex/game";
 
 interface Character {
   _id: string;
@@ -24,18 +23,6 @@ interface CharacterCardProps {
   onKillCharacter?: () => void;
   onUpgradeDifficulty?: (newDifficulty: "medium" | "hard") => void;
 }
-
-const HP_DRAIN_RATES: Record<Difficulty, number> = {
-  easy: 0.5,
-  medium: 1.5,
-  hard: 4.0,
-};
-
-const XP_MULTIPLIERS: Record<Difficulty, number> = {
-  easy: 1,
-  medium: 2,
-  hard: 3,
-};
 
 const DIFFICULTY_COLORS: Record<Difficulty, string> = {
   easy: "text-green-400 border-green-700 bg-green-900/30",

--- a/components/create-character.tsx
+++ b/components/create-character.tsx
@@ -15,23 +15,23 @@ const DIFFICULTY_INFO: Record<Difficulty, { label: string; color: string; hpDrai
   easy: {
     label: "Easy",
     color: "text-green-400",
-    hpDrain: 0.2,
+    hpDrain: 0.5,
     xpMultiplier: 1,
-    description: "1 PR/day total survives 3 repos",
+    description: "~8 days survival without PRs",
   },
   medium: {
     label: "Medium",
     color: "text-yellow-400",
-    hpDrain: 0.5,
+    hpDrain: 1.5,
     xpMultiplier: 2,
-    description: "1 PR/day per repo survives 3 repos",
+    description: "~2.8 days survival without PRs",
   },
   hard: {
     label: "Hard",
     color: "text-red-400",
-    hpDrain: 1.0,
+    hpDrain: 4.0,
     xpMultiplier: 3,
-    description: "2 PRs/day per repo survives 3 repos",
+    description: "~1 day survival without PRs",
   },
 };
 

--- a/components/game-rules.tsx
+++ b/components/game-rules.tsx
@@ -5,15 +5,15 @@ export function GameRules() {
     <div className="grid grid-cols-3 gap-4 text-xs text-gray-600">
       <div>
         <p className="text-gray-500 mb-1">HP Drain (per repo)</p>
-        <p className="text-green-600">Easy: -0.2/hr (~5/day)</p>
-        <p className="text-yellow-600">Medium: -0.5/hr (~12/day)</p>
-        <p className="text-red-600">Hard: -1.0/hr (~24/day)</p>
+        <p className="text-green-600">Easy: -0.5/hr (~12/day)</p>
+        <p className="text-yellow-600">Medium: -1.5/hr (~36/day)</p>
+        <p className="text-red-600">Hard: -4.0/hr (~96/day)</p>
       </div>
       <div>
         <p className="text-gray-500 mb-1">Rewards</p>
         <p>Commit: +10 XP (no HP)</p>
-        <p>PR w/issue: +12 HP, +50 XP</p>
-        <p>PR only: +6 HP, +25 XP</p>
+        <p>PR w/issue: +24 HP, +50 XP</p>
+        <p>PR only: +12 HP, +25 XP</p>
       </div>
       <div>
         <p className="text-gray-500 mb-1">XP Multipliers</p>

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -39,8 +39,8 @@ export const REWARDS = {
   streak30: { hp: 15, xp: 50 },
   streak100: { hp: 30, xp: 200 },
   // Commitments
-  commitmentComplete: { hp: 10, xp: 25 },
-  commitmentRenew: { xp: 25 },
+  commitmentComplete: { hp: 100, xp: 1000 },
+  commitmentRenew: { xp: 250 },
 } as const;
 
 // Helper functions


### PR DESCRIPTION
## Summary
- Create `/rules` page with comprehensive game documentation
- Add Rules nav link to header (left side after ARMORY)
- Fix HP drain rates in UI to match `convex/game.ts` (0.5/1.5/4.0)
- Fix PR rewards display (+24/+12 HP)
- Update commitment rewards to be more impactful
- Import game constants from shared source instead of duplicating

## Changes
| Value | Old | New |
|-------|-----|-----|
| Complete commitment | +10 HP, +25 XP | +100 HP, +1000 XP |
| Renew commitment | +25 XP | +250 XP |

## Test plan
- [ ] Verify Rules link appears in navbar (left side)
- [ ] Verify `/rules` page loads with all sections
- [ ] Verify footer shows correct HP drain rates
- [ ] Verify character creation shows correct values
- [ ] Verify character card calculates drain correctly

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)