### PR TITLE
Add mobile sidebar navigation

### DIFF
--- a/app/u/[username]/content.tsx
+++ b/app/u/[username]/content.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { useQuery } from "convex/react";
-import { useUser } from "@clerk/nextjs";
+import { useUser, UserButton } from "@clerk/nextjs";
 import { api } from "../../../convex/_generated/api";
 import { HpBar } from "@/components/hp-bar";
 import { XpBar } from "@/components/xp-bar";
@@ -21,7 +21,21 @@ const DIFFICULTY_COLORS: Record<Difficulty, string> = {
 
 export function PublicProfileContent({ username }: { username: string }) {
   const profile = useQuery(api.characters.getPublicProfile, { username });
-  const { user: currentUser } = useUser();
+  const { user: currentUser, isSignedIn } = useUser();
+
+  // Build user nav for logged-in users
+  const userNav = isSignedIn && currentUser ? (
+    <>
+      <a
+        href={`/u/${currentUser.username}`}
+        className="text-sm text-[var(--pixel-green)] hover:underline"
+        title="View your profile"
+      >
+        @{currentUser.username}
+      </a>
+      <UserButton afterSignOutUrl="/" />
+    </>
+  ) : null;
 
   useEffect(() => {
     if (profile !== undefined) {
@@ -34,7 +48,7 @@ export function PublicProfileContent({ username }: { username: string }) {
 
   if (profile === undefined) {
     return (
-      <AppShell>
+      <AppShell rightNav={userNav}>
         <p className="text-[var(--pixel-green)]">Loading...</p>
       </AppShell>
     );
@@ -42,7 +56,7 @@ export function PublicProfileContent({ username }: { username: string }) {
 
   if (profile === null) {
     return (
-      <AppShell>
+      <AppShell rightNav={userNav}>
         <div className="pixel-border bg-black p-8 max-w-md text-center">
           <h1 className="text-xl text-red-400 mb-4">Player Not Found</h1>
           <p className="text-gray-400 mb-6">
@@ -62,7 +76,7 @@ export function PublicProfileContent({ username }: { username: string }) {
   const { user, character, commitments, graveyard } = profile;
 
   return (
-    <AppShell centered={false}>
+    <AppShell rightNav={userNav} centered={false}>
       <article className="w-full max-w-2xl" itemScope itemType="https://schema.org/ProfilePage">
         {/* Player info */}
         <header className="flex items-center gap-4 mb-6">

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import Link from "next/link";
 import { GameRules } from "./game-rules";
 
@@ -10,6 +11,8 @@ interface AppShellProps {
 }
 
 export function AppShell({ children, rightNav, centered = true }: AppShellProps) {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
   return (
     <div className="min-h-screen flex flex-col">
       {/* Navbar - full width */}
@@ -18,11 +21,14 @@ export function AppShell({ children, rightNav, centered = true }: AppShellProps)
           <Link href="/" className="text-xl text-[var(--pixel-gold)] hover:opacity-80">
             ARMORY
           </Link>
-          <Link href="/rules" className="text-gray-500 hover:text-gray-400 text-xs">
+          {/* Desktop only: Rules link */}
+          <Link href="/rules" className="hidden sm:block text-gray-500 hover:text-gray-400 text-xs">
             Rules
           </Link>
         </div>
-        <div className="flex items-center gap-4">
+
+        {/* Desktop nav */}
+        <div className="hidden sm:flex items-center gap-4">
           {rightNav}
           <a
             href="https://github.com/bustakar/armory"
@@ -33,7 +39,76 @@ export function AppShell({ children, rightNav, centered = true }: AppShellProps)
             GitHub
           </a>
         </div>
+
+        {/* Mobile: hamburger button */}
+        <button
+          onClick={() => setSidebarOpen(true)}
+          className="sm:hidden p-2 text-gray-400 hover:text-white"
+          aria-label="Open menu"
+        >
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
       </header>
+
+      {/* Mobile sidebar overlay */}
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 z-40 sm:hidden"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
+
+      {/* Mobile sidebar */}
+      <div
+        className={`fixed top-0 right-0 h-full w-64 bg-gray-900 border-l border-gray-700 z-50 transform transition-transform duration-200 ease-in-out sm:hidden ${
+          sidebarOpen ? "translate-x-0" : "translate-x-full"
+        }`}
+      >
+        <div className="flex flex-col h-full">
+          {/* Sidebar header */}
+          <div className="flex justify-between items-center p-4 border-b border-gray-700">
+            <span className="text-[var(--pixel-gold)] font-bold">Menu</span>
+            <button
+              onClick={() => setSidebarOpen(false)}
+              className="p-2 text-gray-400 hover:text-white"
+              aria-label="Close menu"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Sidebar content */}
+          <nav className="flex-1 p-4 space-y-4">
+            {/* User info if provided */}
+            {rightNav && (
+              <div className="pb-4 border-b border-gray-700">
+                {rightNav}
+              </div>
+            )}
+
+            {/* Navigation links */}
+            <Link
+              href="/rules"
+              onClick={() => setSidebarOpen(false)}
+              className="block py-2 text-gray-300 hover:text-white"
+            >
+              Rules
+            </Link>
+            <a
+              href="https://github.com/bustakar/armory"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="block py-2 text-gray-300 hover:text-white"
+            >
+              GitHub
+            </a>
+          </nav>
+        </div>
+      </div>
 
       {/* Main content */}
       <main


### PR DESCRIPTION
## Summary
- Add hamburger menu on mobile devices
- Slide-out sidebar containing: user tag, Rules link, GitHub link
- Desktop navigation unchanged

## Implementation
- Hamburger icon visible on `sm:hidden` breakpoint
- Sidebar slides in from right with dark overlay backdrop
- Close on backdrop click or navigation link click
- Smooth CSS transition animation

## Test plan
- [ ] Desktop: verify nav looks unchanged (Rules left, user/GitHub right)
- [ ] Mobile: tap hamburger → sidebar opens
- [ ] Mobile: tap backdrop → sidebar closes
- [ ] Mobile: tap link → navigates and closes sidebar
- [ ] Mobile: user tag displays in sidebar when logged in

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)