### PR TITLE
Add global leaderboard with homepage preview

### DIFF
--- a/app/leaderboard/content.tsx
+++ b/app/leaderboard/content.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from "next/link";
+import { AppShell } from "@/components/app-shell";
+import { Leaderboard } from "@/components/leaderboard";
+
+export function LeaderboardContent() {
+  return (
+    <AppShell centered={false}>
+      <div className="w-full max-w-2xl pb-8">
+        <div className="flex items-center justify-between mb-6">
+          <h1 className="text-2xl text-[var(--pixel-gold)]">LEADERBOARD</h1>
+          <Link
+            href="/"
+            className="text-xs text-gray-500 hover:text-gray-400"
+          >
+            ← Back to game
+          </Link>
+        </div>
+        <Leaderboard />
+      </div>
+    </AppShell>
+  );
+}

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import { LeaderboardContent } from "./content";
+
+export const metadata: Metadata = {
+  title: "Leaderboard | Armory",
+  description: "See the top players in Armory ranked by XP. View all-time rankings or filter by this month or week.",
+};
+
+export default function LeaderboardPage() {
+  return <LeaderboardContent />;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,43 +7,50 @@ import {
 import { SignInButton } from "@clerk/nextjs";
 import Link from "next/link";
 import { AppShell } from "@/components/app-shell";
+import { LeaderboardPreview } from "@/components/leaderboard-preview";
 
 export default function Home() {
   return (
-    <AppShell>
-      <article className="pixel-border bg-black p-8 max-w-lg text-center">
-        <header>
-          <h1 className="text-2xl text-[var(--pixel-gold)] mb-6">ARMORY</h1>
-          <p className="text-sm text-gray-400 mb-2">Developer Survival Game</p>
-        </header>
+    <AppShell centered={false}>
+      <div className="w-full max-w-lg flex flex-col gap-6">
+        {/* Main Card */}
+        <article className="pixel-border bg-black p-8 text-center">
+          <header>
+            <h1 className="text-2xl text-[var(--pixel-gold)] mb-6">ARMORY</h1>
+            <p className="text-sm text-gray-400 mb-2">Developer Survival Game</p>
+          </header>
 
-        <p className="text-xs text-gray-600 mb-8">
-          Stake your HP on GitHub activity. Survive or perish.
-        </p>
+          <p className="text-xs text-gray-600 mb-8">
+            Stake your HP on GitHub activity. Survive or perish.
+          </p>
 
-        <nav aria-label="Main actions">
-          <Unauthenticated>
-            <SignInButton mode="modal">
-              <button
-                className="w-full bg-[var(--pixel-green)] text-black py-3 hover:bg-[var(--pixel-dark-green)] transition-colors"
-                aria-label="Sign in with GitHub to start playing"
+          <nav aria-label="Main actions">
+            <Unauthenticated>
+              <SignInButton mode="modal">
+                <button
+                  className="w-full bg-[var(--pixel-green)] text-black py-3 hover:bg-[var(--pixel-dark-green)] transition-colors"
+                  aria-label="Sign in with GitHub to start playing"
+                >
+                  SIGN IN WITH GITHUB
+                </button>
+              </SignInButton>
+            </Unauthenticated>
+
+            <Authenticated>
+              <Link
+                href="/dashboard"
+                className="block w-full bg-[var(--pixel-green)] text-black py-3 hover:bg-[var(--pixel-dark-green)] transition-colors"
+                aria-label="Go to your dashboard"
               >
-                SIGN IN WITH GITHUB
-              </button>
-            </SignInButton>
-          </Unauthenticated>
+                ENTER ARMORY
+              </Link>
+            </Authenticated>
+          </nav>
+        </article>
 
-          <Authenticated>
-            <Link
-              href="/dashboard"
-              className="block w-full bg-[var(--pixel-green)] text-black py-3 hover:bg-[var(--pixel-dark-green)] transition-colors"
-              aria-label="Go to your dashboard"
-            >
-              ENTER ARMORY
-            </Link>
-          </Authenticated>
-        </nav>
-      </article>
+        {/* Leaderboard Preview */}
+        <LeaderboardPreview />
+      </div>
     </AppShell>
   );
 }

--- a/components/app-shell.tsx
+++ b/components/app-shell.tsx
@@ -21,7 +21,10 @@ export function AppShell({ children, rightNav, centered = true }: AppShellProps)
           <Link href="/" className="text-xl text-[var(--pixel-gold)] hover:opacity-80">
             ARMORY
           </Link>
-          {/* Desktop only: Rules link */}
+          {/* Desktop only: Nav links */}
+          <Link href="/leaderboard" className="hidden sm:block text-gray-500 hover:text-gray-400 text-xs">
+            Leaderboard
+          </Link>
           <Link href="/rules" className="hidden sm:block text-gray-500 hover:text-gray-400 text-xs">
             Rules
           </Link>
@@ -91,6 +94,13 @@ export function AppShell({ children, rightNav, centered = true }: AppShellProps)
             )}
 
             {/* Navigation links */}
+            <Link
+              href="/leaderboard"
+              onClick={() => setSidebarOpen(false)}
+              className="block py-2 text-gray-300 hover:text-white"
+            >
+              Leaderboard
+            </Link>
             <Link
               href="/rules"
               onClick={() => setSidebarOpen(false)}

--- a/components/leaderboard-preview.tsx
+++ b/components/leaderboard-preview.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useQuery } from "convex/react";
+import { api } from "../convex/_generated/api";
+import Link from "next/link";
+
+const RANK_COLORS: Record<number, string> = {
+  1: "text-yellow-400", // Gold
+  2: "text-gray-300",   // Silver
+  3: "text-amber-600",  // Bronze
+};
+
+export function LeaderboardPreview() {
+  const topPlayers = useQuery(api.leaderboard.getTopPlayers);
+
+  if (topPlayers === undefined) {
+    return (
+      <div className="pixel-border bg-black p-4 w-full">
+        <h3 className="text-sm text-gray-400 mb-3">TOP PLAYERS</h3>
+        <p className="text-xs text-gray-600">Loading...</p>
+      </div>
+    );
+  }
+
+  if (topPlayers.length === 0) {
+    return (
+      <div className="pixel-border bg-black p-4 w-full">
+        <h3 className="text-sm text-gray-400 mb-3">TOP PLAYERS</h3>
+        <p className="text-xs text-gray-600">No players yet. Be the first!</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pixel-border bg-black p-4 w-full">
+      <div className="flex justify-between items-center mb-3">
+        <h3 className="text-sm text-gray-400">TOP PLAYERS</h3>
+        <Link
+          href="/leaderboard"
+          className="text-xs text-[var(--pixel-green)] hover:underline"
+        >
+          View All →
+        </Link>
+      </div>
+
+      <ul className="space-y-2">
+        {topPlayers.map((player) => (
+          <li key={player.githubUsername} className="flex items-center gap-3">
+            {/* Rank */}
+            <span className={`w-6 text-sm font-bold ${RANK_COLORS[player.rank] || "text-gray-500"}`}>
+              #{player.rank}
+            </span>
+
+            {/* Avatar */}
+            {player.avatarUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={player.avatarUrl}
+                alt=""
+                className="w-6 h-6 border border-gray-700"
+                style={{ imageRendering: "pixelated" }}
+              />
+            ) : (
+              <div className="w-6 h-6 bg-gray-800 border border-gray-700" />
+            )}
+
+            {/* Name & Level */}
+            <Link
+              href={`/u/${player.githubUsername}`}
+              className="flex-1 truncate text-sm text-gray-300 hover:text-[var(--pixel-green)]"
+            >
+              {player.characterName}
+            </Link>
+
+            {/* Level */}
+            <span className="text-xs text-gray-500">Lv{player.level}</span>
+
+            {/* XP */}
+            <span className="text-xs text-[var(--pixel-gold)] w-16 text-right">
+              {player.xp.toLocaleString()} XP
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/leaderboard.tsx
+++ b/components/leaderboard.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState } from "react";
+import { useQuery } from "convex/react";
+import { api } from "../convex/_generated/api";
+import Link from "next/link";
+
+type FilterType = "all" | "month" | "week";
+type Difficulty = "easy" | "medium" | "hard";
+
+const RANK_COLORS: Record<number, string> = {
+  1: "text-yellow-400", // Gold
+  2: "text-gray-300",   // Silver
+  3: "text-amber-600",  // Bronze
+};
+
+const RANK_BG: Record<number, string> = {
+  1: "bg-yellow-900/20",
+  2: "bg-gray-700/20",
+  3: "bg-amber-900/20",
+};
+
+const DIFFICULTY_COLORS: Record<Difficulty, string> = {
+  easy: "text-green-400",
+  medium: "text-yellow-400",
+  hard: "text-red-400",
+};
+
+const FILTER_LABELS: Record<FilterType, string> = {
+  all: "ALL TIME",
+  month: "THIS MONTH",
+  week: "THIS WEEK",
+};
+
+export function Leaderboard() {
+  const [filter, setFilter] = useState<FilterType>("all");
+  const leaderboard = useQuery(api.leaderboard.getLeaderboard, { filter, limit: 100 });
+
+  return (
+    <div className="w-full max-w-2xl">
+      {/* Filter tabs */}
+      <div className="flex gap-1 bg-gray-900 p-1 border border-gray-700 w-fit mb-6">
+        {(Object.keys(FILTER_LABELS) as FilterType[]).map((f) => (
+          <button
+            key={f}
+            onClick={() => setFilter(f)}
+            className={`px-3 py-1 text-xs transition-colors ${
+              filter === f
+                ? "bg-[var(--pixel-green)] text-black"
+                : "text-gray-400 hover:text-white"
+            }`}
+          >
+            {FILTER_LABELS[f]}
+          </button>
+        ))}
+      </div>
+
+      {/* Loading state */}
+      {leaderboard === undefined && (
+        <div className="pixel-border bg-black p-8 text-center">
+          <p className="text-[var(--pixel-green)]">Loading...</p>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {leaderboard && leaderboard.length === 0 && (
+        <div className="pixel-border bg-black p-8 text-center">
+          <p className="text-gray-400">
+            {filter === "all"
+              ? "No players yet. Be the first to join!"
+              : `No activity ${filter === "month" ? "this month" : "this week"}.`}
+          </p>
+        </div>
+      )}
+
+      {/* Leaderboard list */}
+      {leaderboard && leaderboard.length > 0 && (
+        <div className="pixel-border bg-black">
+          {/* Table header */}
+          <div className="hidden sm:grid grid-cols-[3rem_1fr_4rem_5rem_4rem_5rem] gap-2 px-4 py-2 border-b border-gray-700 text-xs text-gray-500">
+            <span>RANK</span>
+            <span>PLAYER</span>
+            <span className="text-right">LEVEL</span>
+            <span className="text-right">XP</span>
+            <span className="text-right">STREAK</span>
+            <span className="text-right">MODE</span>
+          </div>
+
+          {/* Players */}
+          <ul>
+            {leaderboard.map((player) => (
+              <li
+                key={player.githubUsername}
+                className={`border-b border-gray-800 last:border-b-0 ${RANK_BG[player.rank] || ""}`}
+              >
+                <Link
+                  href={`/u/${player.githubUsername}`}
+                  className="flex flex-col sm:grid sm:grid-cols-[3rem_1fr_4rem_5rem_4rem_5rem] gap-2 sm:gap-2 px-4 py-3 hover:bg-gray-800/50 transition-colors"
+                >
+                  {/* Mobile: Row 1 - Rank, Avatar, Name */}
+                  <div className="flex items-center gap-3 sm:contents">
+                    {/* Rank */}
+                    <span className={`text-lg sm:text-sm font-bold sm:self-center ${RANK_COLORS[player.rank] || "text-gray-500"}`}>
+                      #{player.rank}
+                    </span>
+
+                    {/* Avatar + Name container */}
+                    <div className="flex items-center gap-2 flex-1 sm:flex-none sm:overflow-hidden">
+                      {player.avatarUrl ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img
+                          src={player.avatarUrl}
+                          alt=""
+                          className="w-8 h-8 sm:w-6 sm:h-6 border border-gray-700"
+                          style={{ imageRendering: "pixelated" }}
+                        />
+                      ) : (
+                        <div className="w-8 h-8 sm:w-6 sm:h-6 bg-gray-800 border border-gray-700" />
+                      )}
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm text-gray-200 truncate">{player.characterName}</p>
+                        <p className="text-xs text-gray-500 sm:hidden">@{player.githubUsername}</p>
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Mobile: Row 2 - Stats */}
+                  <div className="flex justify-between sm:contents text-xs sm:text-sm pl-10 sm:pl-0">
+                    <span className="text-gray-400 sm:text-gray-300 sm:text-right sm:self-center">
+                      <span className="sm:hidden">Lv</span>{player.level}
+                    </span>
+                    <span className="text-[var(--pixel-gold)] sm:text-right sm:self-center">
+                      {player.xp.toLocaleString()}<span className="sm:hidden"> XP</span>
+                    </span>
+                    <span className="text-gray-400 sm:text-right sm:self-center">
+                      {player.streak}<span className="sm:hidden">d</span>
+                    </span>
+                    <span className={`sm:text-right sm:self-center ${DIFFICULTY_COLORS[player.difficulty as Difficulty]}`}>
+                      {(player.difficulty as string).toUpperCase()}
+                    </span>
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Filter description */}
+      <p className="text-xs text-gray-600 mt-4 text-center">
+        {filter === "all"
+          ? "Total XP earned across all time"
+          : filter === "month"
+          ? "XP earned in the last 30 days"
+          : "XP earned in the last 7 days"}
+      </p>
+    </div>
+  );
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -15,6 +15,7 @@ import type * as crypto from "../crypto.js";
 import type * as game from "../game.js";
 import type * as github from "../github.js";
 import type * as githubActions from "../githubActions.js";
+import type * as leaderboard from "../leaderboard.js";
 import type * as lib_errors from "../lib/errors.js";
 import type * as scanner from "../scanner.js";
 import type * as scannerMutations from "../scannerMutations.js";
@@ -35,6 +36,7 @@ declare const fullApi: ApiFromModules<{
   game: typeof game;
   github: typeof github;
   githubActions: typeof githubActions;
+  leaderboard: typeof leaderboard;
   "lib/errors": typeof lib_errors;
   scanner: typeof scanner;
   scannerMutations: typeof scannerMutations;

--- a/convex/leaderboard.ts
+++ b/convex/leaderboard.ts
@@ -1,0 +1,132 @@
+import { query } from "./_generated/server";
+import { v } from "convex/values";
+import { Id } from "./_generated/dataModel";
+
+// Get top 10 players for homepage preview
+export const getTopPlayers = query({
+  handler: async (ctx) => {
+    // Get all living characters sorted by XP (descending)
+    const characters = await ctx.db
+      .query("characters")
+      .filter((q) => q.eq(q.field("isAlive"), true))
+      .collect();
+
+    // Sort by XP descending
+    characters.sort((a, b) => b.xp - a.xp);
+
+    // Take top 10
+    const top10 = characters.slice(0, 10);
+
+    // Get user data for each character
+    const results = await Promise.all(
+      top10.map(async (char, index) => {
+        const user = await ctx.db.get(char.userId);
+        return {
+          rank: index + 1,
+          characterName: char.name,
+          level: char.level,
+          xp: char.xp,
+          githubUsername: user?.githubUsername || "unknown",
+          avatarUrl: user?.avatarUrl,
+        };
+      })
+    );
+
+    return results;
+  },
+});
+
+// Get full leaderboard with time filtering
+export const getLeaderboard = query({
+  args: {
+    filter: v.union(v.literal("all"), v.literal("month"), v.literal("week")),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const limit = args.limit || 100;
+    const now = Date.now();
+
+    // For "all" time, just use character XP directly (efficient)
+    if (args.filter === "all") {
+      const characters = await ctx.db
+        .query("characters")
+        .filter((q) => q.eq(q.field("isAlive"), true))
+        .collect();
+
+      // Sort by XP descending
+      characters.sort((a, b) => b.xp - a.xp);
+
+      // Take top N
+      const topN = characters.slice(0, limit);
+
+      // Get user data for each character
+      const results = await Promise.all(
+        topN.map(async (char, index) => {
+          const user = await ctx.db.get(char.userId);
+          return {
+            rank: index + 1,
+            characterName: char.name,
+            level: char.level,
+            xp: char.xp,
+            streak: char.streak,
+            difficulty: char.difficulty || "easy",
+            githubUsername: user?.githubUsername || "unknown",
+            avatarUrl: user?.avatarUrl,
+          };
+        })
+      );
+
+      return results;
+    }
+
+    // For time-filtered leaderboards, aggregate from activityLogs
+    const startTime = args.filter === "month"
+      ? now - 30 * 24 * 60 * 60 * 1000 // 30 days
+      : now - 7 * 24 * 60 * 60 * 1000; // 7 days
+
+    // Get all activity logs in the time range
+    const activityLogs = await ctx.db
+      .query("activityLogs")
+      .collect();
+
+    // Filter by timestamp and aggregate XP by character
+    const xpByCharacter = new Map<Id<"characters">, number>();
+    for (const log of activityLogs) {
+      if (log.timestamp >= startTime) {
+        const key = log.characterId;
+        const current = xpByCharacter.get(key) || 0;
+        xpByCharacter.set(key, current + log.xpGained);
+      }
+    }
+
+    // Get character IDs sorted by XP in the period
+    const sortedCharacterIds = Array.from(xpByCharacter.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, limit);
+
+    // Get character and user data
+    const results = await Promise.all(
+      sortedCharacterIds.map(async ([characterId, periodXp], index) => {
+        const char = await ctx.db.get(characterId);
+        if (!char || !char.isAlive) return null;
+
+        const user = await ctx.db.get(char.userId);
+        return {
+          rank: index + 1,
+          characterName: char.name,
+          level: char.level,
+          xp: periodXp, // XP gained in this period
+          streak: char.streak,
+          difficulty: char.difficulty || "easy",
+          githubUsername: user?.githubUsername || "unknown",
+          avatarUrl: user?.avatarUrl,
+        };
+      })
+    );
+
+    // Filter out nulls (dead characters) and re-rank
+    return results
+      .filter((r): r is NonNullable<typeof r> => r !== null)
+      .map((r, index) => ({ ...r, rank: index + 1 }));
+  },
+});


### PR DESCRIPTION
## Summary
- Add global leaderboard showing top players ranked by XP
- Homepage displays compact "Top 10" preview widget
- Dedicated `/leaderboard` page with full rankings and time filters (ALL TIME, THIS MONTH, THIS WEEK)
- Navigation links added to desktop navbar and mobile sidebar

Closes #5

## Changes
- `convex/leaderboard.ts` - Backend queries for top players and filtered leaderboard
- `components/leaderboard-preview.tsx` - Compact homepage widget
- `components/leaderboard.tsx` - Full leaderboard with time filter tabs
- `app/leaderboard/` - Dedicated page with SEO metadata
- `app/page.tsx` - Added leaderboard preview, positioned content below navbar
- `components/app-shell.tsx` - Added Leaderboard nav links

## Test plan
- [ ] Verify homepage shows top 10 players preview
- [ ] Click "View All" navigates to /leaderboard
- [ ] Test time filter tabs (ALL TIME, THIS MONTH, THIS WEEK)
- [ ] Click player name navigates to /u/[username] profile
- [ ] Verify Leaderboard link appears in navbar (desktop)
- [ ] Verify Leaderboard link appears in mobile sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)