### PR TITLE
Add custom commitment length selection (1, 2, or 4 weeks)

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -154,9 +154,9 @@ export default function Dashboard() {
     }
   };
 
-  const handleActivate = async (owner: string, repo: string, isPrivate: boolean) => {
+  const handleActivate = async (owner: string, repo: string, isPrivate: boolean, commitmentDays: number) => {
     try {
-      await activateCommitment({ owner, repo, isPrivate });
+      await activateCommitment({ owner, repo, isPrivate, commitmentDays });
       showSuccess(`Committed to ${owner}/${repo}`);
     } catch (error) {
       console.error("Failed to activate commitment:", error);

--- a/components/commitment-list.tsx
+++ b/components/commitment-list.tsx
@@ -4,12 +4,20 @@ import { useMemo } from "react";
 import { formatTimeRemaining } from "@/lib/utils";
 import { analytics } from "@/lib/analytics";
 
+// XP rewards by commitment length
+const COMMITMENT_XP: Record<number, number> = {
+  7: 1000,
+  14: 2500,
+  28: 10000,
+};
+
 interface Commitment {
   _id: string;
   owner: string;
   repo: string;
   activatedAt: number;
   commitmentEndsAt: number;
+  commitmentDays?: number;
   totalCommits: number;
   totalIssuesClosed: number;
   totalPrsMerged: number;
@@ -116,7 +124,7 @@ export function CommitmentList({
                     }}
                     className="flex-1 bg-green-700 hover:bg-green-600 text-white text-xs py-2 px-3 transition-colors"
                   >
-                    Renew (+25 XP)
+                    Renew (+250 XP)
                   </button>
                   <button
                     onClick={() => {
@@ -125,7 +133,7 @@ export function CommitmentList({
                     }}
                     className="flex-1 bg-gray-700 hover:bg-gray-600 text-white text-xs py-2 px-3 transition-colors"
                   >
-                    Complete
+                    Complete (+{(COMMITMENT_XP[commitment.commitmentDays ?? 28] ?? 1000).toLocaleString()} XP)
                   </button>
                 </>
               ) : (

--- a/components/repo-selector.tsx
+++ b/components/repo-selector.tsx
@@ -3,6 +3,15 @@
 import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { analytics } from "@/lib/analytics";
 
+// Commitment length options with scaling XP rewards
+const COMMITMENT_OPTIONS = [
+  { days: 7, label: "1 week", xp: 1000 },
+  { days: 14, label: "2 weeks", xp: 2500 },
+  { days: 28, label: "4 weeks", xp: 10000 },
+] as const;
+
+type CommitmentDays = 7 | 14 | 28;
+
 interface Repo {
   owner: { login: string };
   name: string;
@@ -13,7 +22,7 @@ interface Repo {
 interface RepoSelectorProps {
   repos: Repo[];
   activeRepoNames: string[];
-  onActivate: (owner: string, repo: string, isPrivate: boolean) => void;
+  onActivate: (owner: string, repo: string, isPrivate: boolean, days: number) => void;
   isLoading: boolean;
   error?: string | null;
   onRetry?: () => void;
@@ -29,6 +38,7 @@ export function RepoSelector({
 }: RepoSelectorProps) {
   const [search, setSearch] = useState("");
   const [isOpen, setIsOpen] = useState(false);
+  const [selectedDays, setSelectedDays] = useState<CommitmentDays>(7);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const filteredRepos = useMemo(
@@ -88,6 +98,25 @@ export function RepoSelector({
 
       {isOpen && (
         <div className="mt-2" id="repo-dropdown" role="listbox">
+          {/* Commitment length selector */}
+          <div className="flex gap-1 mb-3">
+            {COMMITMENT_OPTIONS.map((opt) => (
+              <button
+                key={opt.days}
+                type="button"
+                onClick={() => setSelectedDays(opt.days)}
+                className={`flex-1 px-2 py-1.5 text-xs border transition-colors ${
+                  selectedDays === opt.days
+                    ? "bg-green-800 border-green-600 text-green-200"
+                    : "bg-gray-800 border-gray-600 text-gray-400 hover:bg-gray-700"
+                }`}
+              >
+                <div>{opt.label}</div>
+                <div className="text-[10px] opacity-75">+{opt.xp.toLocaleString()} XP</div>
+              </button>
+            ))}
+          </div>
+
           <input
             type="text"
             value={search}
@@ -108,7 +137,7 @@ export function RepoSelector({
                   aria-selected={false}
                   onClick={() => {
                     analytics.commitmentActivated({ repo: repo.full_name, isPrivate: repo.isPrivate ?? false });
-                    onActivate(repo.owner.login, repo.name, repo.isPrivate ?? false);
+                    onActivate(repo.owner.login, repo.name, repo.isPrivate ?? false, selectedDays);
                     setIsOpen(false);
                     setSearch("");
                   }}
@@ -122,7 +151,7 @@ export function RepoSelector({
           </div>
 
           <p className="text-xs text-gray-500 mt-2">
-            30-day commitment - 0.2 HP drain/hour
+            Longer commitments = bigger XP rewards
           </p>
         </div>
       )}

--- a/convex/commitments.ts
+++ b/convex/commitments.ts
@@ -1,11 +1,11 @@
 import { mutation, query } from "./_generated/server";
 import { v } from "convex/values";
 import {
-  COMMITMENT_DAYS,
   EARLY_EXIT_PENALTY,
   REWARDS,
   daysToMs,
   clampHp,
+  getCommitmentReward,
 } from "./game";
 
 // Get active commitments for current user
@@ -57,8 +57,13 @@ export const activate = mutation({
     owner: v.string(),
     repo: v.string(),
     isPrivate: v.optional(v.boolean()),
+    commitmentDays: v.optional(v.number()), // 7, 14, or 28 (defaults to 7)
   },
   handler: async (ctx, args) => {
+    const days = args.commitmentDays ?? 7;
+    if (![7, 14, 28].includes(days)) {
+      throw new Error("Invalid commitment length. Must be 7, 14, or 28 days.");
+    }
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new Error("Not authenticated");
 
@@ -104,7 +109,8 @@ export const activate = mutation({
       repo: args.repo,
       isPrivate: args.isPrivate,
       activatedAt: now,
-      commitmentEndsAt: now + daysToMs(COMMITMENT_DAYS),
+      commitmentEndsAt: now + daysToMs(days),
+      commitmentDays: days,
       renewalCount: 0,
       totalCommits: 0,
       totalIssuesClosed: 0,
@@ -164,12 +170,13 @@ export const deactivate = mutation({
         }
       }
     } else {
-      // Completed commitment bonus
+      // Completed commitment bonus (scaled by commitment length)
       const character = await ctx.db.get(commitment.characterId);
       if (character && character.isAlive) {
+        const reward = getCommitmentReward(commitment.commitmentDays ?? 28);
         await ctx.db.patch(commitment.characterId, {
-          hp: clampHp(character.hp + REWARDS.commitmentComplete.hp),
-          xp: character.xp + REWARDS.commitmentComplete.xp,
+          hp: clampHp(character.hp + reward.hp),
+          xp: character.xp + reward.xp,
         });
       }
     }
@@ -178,7 +185,7 @@ export const deactivate = mutation({
   },
 });
 
-// Renew a commitment for another 30 days
+// Renew a commitment for the same length
 export const renew = mutation({
   args: {
     commitmentId: v.id("commitments"),
@@ -209,9 +216,10 @@ export const renew = mutation({
       throw new Error("Commitment period not yet complete");
     }
 
-    // Renew for another 30 days
+    // Renew for the same length as the original commitment
+    const days = commitment.commitmentDays ?? 28;
     await ctx.db.patch(args.commitmentId, {
-      commitmentEndsAt: now + daysToMs(COMMITMENT_DAYS),
+      commitmentEndsAt: now + daysToMs(days),
       renewalCount: commitment.renewalCount + 1,
     });
 

--- a/convex/game.ts
+++ b/convex/game.ts
@@ -1,8 +1,17 @@
 // Game constants
 export const EARLY_EXIT_PENALTY = 50;
-export const COMMITMENT_DAYS = 30;
+export const COMMITMENT_DAYS = 28; // Default commitment length (legacy)
 export const MAX_HP = 100;
 export const XP_PER_LEVEL = 100;
+
+// Commitment length options with scaling rewards
+export const COMMITMENT_OPTIONS = [
+  { days: 7, label: "1 week", xp: 1000 },
+  { days: 14, label: "2 weeks", xp: 2500 },
+  { days: 28, label: "4 weeks", xp: 10000 },
+] as const;
+
+export type CommitmentDays = 7 | 14 | 28;
 
 // Diversity bonus: +20% XP per additional repo contributed to in 6-hour window
 export const DIVERSITY_MULTIPLIER_STEP = 0.2;
@@ -54,6 +63,11 @@ export function calculateHpDrain(activeRepoCount: number, hours: number = 1, dif
 
 export function clampHp(hp: number): number {
   return Math.max(0, Math.min(MAX_HP, hp));
+}
+
+export function getCommitmentReward(days: number): { hp: number; xp: number } {
+  const option = COMMITMENT_OPTIONS.find((o) => o.days === days);
+  return { hp: 100, xp: option?.xp ?? 1000 };
 }
 
 export function getDeathCause(activeRepoCount: number): string {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -31,7 +31,7 @@ export default defineSchema({
     difficulty: v.optional(v.union(v.literal("easy"), v.literal("medium"), v.literal("hard"))), // Defaults to "easy" for existing characters
   }).index("by_user", ["userId"]),
 
-  // 30-day commitment cycles
+  // Commitment cycles (1, 2, or 4 weeks)
   commitments: defineTable({
     userId: v.id("users"),
     characterId: v.id("characters"),
@@ -39,7 +39,8 @@ export default defineSchema({
     repo: v.string(), // GitHub repo
     isPrivate: v.optional(v.boolean()), // Whether repo is private (hidden in public profile)
     activatedAt: v.number(), // Timestamp
-    commitmentEndsAt: v.number(), // activatedAt + 30 days
+    commitmentEndsAt: v.number(), // activatedAt + commitmentDays
+    commitmentDays: v.optional(v.number()), // 7, 14, or 28 (optional for backwards compat)
     deactivatedAt: v.optional(v.number()), // Set when commitment ends
     wasEarlyExit: v.optional(v.boolean()),
     renewalCount: v.number(), // Number of times renewed


### PR DESCRIPTION
## Summary
- Allow players to choose commitment length: 1 week, 2 weeks, or 4 weeks
- Scaling XP rewards: 1,000 / 2,500 / 10,000 XP respectively
- HP drain stays consistent regardless of length
- Backwards compatible with existing commitments (defaults to 28 days)

Closes #44

## Changes
- **Schema**: Added `commitmentDays` field to commitments table
- **Backend**: Updated `activate`, `deactivate`, and `renew` mutations to handle variable lengths
- **Frontend**: Added commitment length selector UI with XP previews in repo selector
- **UI**: Complete button now shows actual XP reward based on commitment length

## Test plan
- [ ] Activate a 1-week commitment → verify `commitmentEndsAt` is 7 days out
- [ ] Activate a 4-week commitment → verify `commitmentEndsAt` is 28 days out
- [ ] Complete a commitment → verify correct XP awarded
- [ ] Verify existing commitments still work (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)